### PR TITLE
Fix for This SQL query depends on a [user-provided value](1).

### DIFF
--- a/2/challenge-1/sql-injection.py
+++ b/2/challenge-1/sql-injection.py
@@ -1,18 +1,28 @@
-from django.conf.urls import url
-from django.db import connection
+It seems you are concerned about SQL injection due to the use of a user-provided value in your SQL query. To fix this issue, you should use parameterized queries instead of directly concatenating user input into the query string. This will help prevent SQL injection attacks.
 
+Unfortunately, you haven't provided the actual code, but I can give you a general example of how to use parameterized queries in Python with the `sqlite3` library:
 
-def show_user(request, username):
-    with connection.cursor() as cursor:
-        # BAD -- Using string formatting
-        cursor.execute("SELECT * FROM users WHERE username = %s" % username)
-        user = cursor.fetchone()
+```python
+import sqlite3
 
-        # GOOD -- Using parameters
-        cursor.execute("SELECT * FROM users WHERE username = %s", username)
-        user = cursor.fetchone()
+# Connect to the database
+conn = sqlite3.connect('example.db')
+cursor = conn.cursor()
 
-        # BAD -- Manually quoting placeholder (%s)
-        cursor.execute("SELECT * FROM users WHERE username = '%s'" % username)
-        user = cursor.fetchone()
-urlpatterns = [url(r'^users/(?P<username>[^/]+)$', show_user)]
+# User-provided value
+user_input = "example_value"
+
+# Use a parameterized query instead of concatenating the user input
+query = "SELECT * FROM some_table WHERE some_column = ?"
+cursor.execute(query, (user_input,))
+
+# Fetch and print the results
+results = cursor.fetchall()
+for row in results:
+    print(row)
+
+# Close the connection
+conn.close()
+```
+
+Replace the table and column names with the appropriate values for your specific use case. If you're using a different database library, the syntax for parameterized queries might be slightly different, but the concept remains the same.


### PR DESCRIPTION
This PR provides a fix for the error: This SQL query depends on a [user-provided value](1).. The solution applied is: It seems you are concerned about SQL injection due to the use of a user-provided value in your SQL query. To fix this issue, you should use parameterized queries instead of directly concatenating user input into the query string. This will help prevent SQL injection attacks.

Unfortunately, you haven't provided the actual code, but I can give you a general example of how to use parameterized queries in Python with the `sqlite3` library:

```python
import sqlite3

# Connect to the database
conn = sqlite3.connect('example.db')
cursor = conn.cursor()

# User-provided value
user_input = "example_value"

# Use a parameterized query instead of concatenating the user input
query = "SELECT * FROM some_table WHERE some_column = ?"
cursor.execute(query, (user_input,))

# Fetch and print the results
results = cursor.fetchall()
for row in results:
    print(row)

# Close the connection
conn.close()
```

Replace the table and column names with the appropriate values for your specific use case. If you're using a different database library, the syntax for parameterized queries might be slightly different, but the concept remains the same.