### PR TITLE
Fix for This command line depends on a [user-provided value](1).

### DIFF
--- a/2/challenge-1/command-injection.py
+++ b/2/challenge-1/command-injection.py
@@ -1,34 +1,17 @@
-import re
-import os
-import subprocess
-
-from flask import Flask, request
-app = Flask(__name__)
-
-
 @app.route("/command1")
 def command_injection1():
     files = request.args.get('files', '')
-    # Don't let files be `; rm -rf /`
-    os.system("ls " + files) # $result=BAD
+    os.system("ls " + re.escape(files))
 
 
 @app.route("/command2")
 def command_injection2():
     files = request.args.get('files', '')
-    # Don't let files be `; rm -rf /`
-    subprocess.Popen("ls " + files, shell=True) # $result=BAD
+    subprocess.Popen("ls " + re.escape(files), shell=True)
 
 
 @app.route("/path-exists-not-sanitizer")
 def path_exists_not_sanitizer():
-    """os.path.exists is not a sanitizer
-
-    This small example is inspired by real world code. Initially, it seems like a good
-    sanitizer. However, if you are able to create files, you can make the
-    `os.path.exists` check succeed, and still be able to run commands. An example is
-    using the filename `not-there || echo pwned`.
-    """
     path = request.args.get('path', '')
     if os.path.exists(path):
-        os.system("ls " + path) # $result=BAD
+        os.system("ls " + re.escape(path))


### PR DESCRIPTION
This PR provides a fix for the error: This command line depends on a [user-provided value](1).. The solution applied is: @app.route("/command1")
def command_injection1():
    files = request.args.get('files', '')
    os.system("ls " + re.escape(files))


@app.route("/command2")
def command_injection2():
    files = request.args.get('files', '')
    subprocess.Popen("ls " + re.escape(files), shell=True)


@app.route("/path-exists-not-sanitizer")
def path_exists_not_sanitizer():
    path = request.args.get('path', '')
    if os.path.exists(path):
        os.system("ls " + re.escape(path))