### PR TITLE
Fix for This SQL query depends on a [user-provided value](1).

### DIFF
--- a/2/challenge-1/sql-injection.py
+++ b/2/challenge-1/sql-injection.py
@@ -1,18 +1,10 @@
 from django.conf.urls import url
 from django.db import connection
 
-
 def show_user(request, username):
     with connection.cursor() as cursor:
-        # BAD -- Using string formatting
-        cursor.execute("SELECT * FROM users WHERE username = %s" % username)
-        user = cursor.fetchone()
-
         # GOOD -- Using parameters
-        cursor.execute("SELECT * FROM users WHERE username = %s", username)
+        cursor.execute("SELECT * FROM users WHERE username = %s", [username])
         user = cursor.fetchone()
 
-        # BAD -- Manually quoting placeholder (%s)
-        cursor.execute("SELECT * FROM users WHERE username = '%s'" % username)
-        user = cursor.fetchone()
 urlpatterns = [url(r'^users/(?P<username>[^/]+)$', show_user)]


### PR DESCRIPTION

                ### [py/sql-injection]: This SQL query depends on a [user-provided value](1).

                Path: [2/challenge-1/sql-injection.py](https://github.com/canonicalmg/codeql-zero-to-hero/blob/main/2/challenge-1/sql-injection.py)

                Code:
                ```javascript
                from django.conf.urls import url
from django.db import connection


def show_user(request, username):
    with connection.cursor() as cursor:
        # BAD -- Using string formatting
        cursor.execute("SELECT * FROM users WHERE username = %s" % username)
        user = cursor.fetchone()

        # GOOD -- Using parameters
        cursor.execute("SELECT * FROM users WHERE username = %s", username)
        user = cursor.fetchone()

        # BAD -- Manually quoting placeholder (%s)
        cursor.execute("SELECT * FROM users WHERE username = '%s'" % username)
        user = cursor.fetchone()
urlpatterns = [url(r'^users/(?P<username>[^/]+)$', show_user)]

                ```

                **Proposed Solution:**
                ```
                from django.conf.urls import url
from django.db import connection

def show_user(request, username):
    with connection.cursor() as cursor:
        # GOOD -- Using parameters
        cursor.execute("SELECT * FROM users WHERE username = %s", [username])
        user = cursor.fetchone()

urlpatterns = [url(r'^users/(?P<username>[^/]+)$', show_user)]
                ```
                