### PR TITLE
Fix for issue related to: py/command-line-injection

### DIFF
--- a/2/challenge-1/command-injection.py
+++ b/2/challenge-1/command-injection.py
@@ -5,30 +5,22 @@ import subprocess
 from flask import Flask, request
 app = Flask(__name__)
 
+ALLOWED_FILES = ["file1", "file2", "file3"]
 
 @app.route("/command1")
 def command_injection1():
     files = request.args.get('files', '')
-    # Don't let files be `; rm -rf /`
-    os.system("ls " + files) # $result=BAD
-
+    if files in ALLOWED_FILES:
+        os.system("ls " + files) # $result=GOOD
 
 @app.route("/command2")
 def command_injection2():
     files = request.args.get('files', '')
-    # Don't let files be `; rm -rf /`
-    subprocess.Popen("ls " + files, shell=True) # $result=BAD
-
+    if files in ALLOWED_FILES:
+        subprocess.Popen("ls " + files, shell=True) # $result=GOOD
 
 @app.route("/path-exists-not-sanitizer")
 def path_exists_not_sanitizer():
-    """os.path.exists is not a sanitizer
-
-    This small example is inspired by real world code. Initially, it seems like a good
-    sanitizer. However, if you are able to create files, you can make the
-    `os.path.exists` check succeed, and still be able to run commands. An example is
-    using the filename `not-there || echo pwned`.
-    """
     path = request.args.get('path', '')
-    if os.path.exists(path):
-        os.system("ls " + path) # $result=BAD
+    if os.path.exists(path) and path in ALLOWED_FILES:
+        os.system("ls " + path) # $result=GOOD


### PR DESCRIPTION
### Recommendation:

# Uncontrolled command line
Code that passes user input directly to `exec`, `eval`, or some other library routine that executes a command, allows the user to execute malicious code.


## Recommendation
If possible, use hard-coded string literals to specify the command to run or the library to load. Instead of passing the user input directly to the process or library function, examine the user input and then choose among hard-coded string literals.

If the applicable libraries or commands cannot be determined at compile time, then add code to verify that the user input string is safe before using it.


## Example
The following example shows two functions. The first is unsafe as it takes a shell script that can be changed by a user, and passes it straight to `subprocess.call()` without examining it first. The second is safe as it selects the command from a predefined allowlist.


```python

urlpatterns = [
    # Route to command_execution
    url(r'^command-ex1$', command_execution_unsafe, name='command-execution-unsafe'),
    url(r'^command-ex2$', command_execution_safe, name='command-execution-safe')
]

COMMANDS = {
    "list" :"ls",
    "stat" : "stat"
}

def command_execution_unsafe(request):
    if request.method == 'POST':
        action = request.POST.get('action', '')
        #BAD -- No sanitizing of input
        subprocess.call(["application", action])

def command_execution_safe(request):
    if request.method == 'POST':
        action = request.POST.get('action', '')
        #GOOD -- Use an allowlist
        subprocess.call(["application", COMMANDS[action]])

```

## References
* OWASP: [Command Injection](https://www.owasp.org/index.php/Command_Injection).
* Common Weakness Enumeration: [CWE-78](https://cwe.mitre.org/data/definitions/78.html).
* Common Weakness Enumeration: [CWE-88](https://cwe.mitre.org/data/definitions/88.html).


---

